### PR TITLE
create temp dir for install and update scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ contents: []
 # Those environment variables are available inside the scenarios:
 # - LATEST_VERSION (in install & update scenarios)
 # - CURRENT_VERSION (in update & uninstall scenario)
+# - TEMP - path to temporary directory that will be removed after scenario (in update & uninstall scenario)
 ```
 </details>

--- a/application/types/common.go
+++ b/application/types/common.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/fatih/color"
@@ -20,4 +21,16 @@ var progressBar = pb.ProgressBarTemplate(fmt.Sprintf(
 func finishProgressBar(bar *pb.ProgressBar) {
 	bar.Finish()
 	fmt.Print("\033[1A\033[K")
+}
+
+// Temp returns temporary directory that can be used by install / update scenarios
+func Temp() (dir string, cleanup func(), err error) {
+	dir, err = os.MkdirTemp("", "myapps")
+	if err != nil {
+		err = fmt.Errorf("Failed to create temp directory for this scenario: %w", err)
+	}
+	cleanup = func() {
+		os.RemoveAll(dir)
+	}
+	return
 }


### PR DESCRIPTION
Temp dir is shared between steps in scenario and removed automatically
after scenario finishes.

This simplifies install/update scripts: no need to use hard coded temp path, no need for cleanup. 

```yaml 
    install_scenario:
        - curl -Ls foo | tar --strip-components 1 -xJf - -C $TEMP
        - cp $TEMP/binary /usr/local/bin/binary
```